### PR TITLE
refactor: make create table idempotent

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -58,7 +58,7 @@ func NewCluster(logger *zap.Logger, metadata *metadata.ClusterMetadata, client *
 	dispatch := eventdispatch.NewDispatchImpl()
 
 	procedureIDRootPath := strings.Join([]string{rootPath, metadata.Name(), defaultProcedurePrefixKey}, "/")
-	procedureFactory := coordinator.NewFactory(logger, id.NewAllocatorImpl(logger, client, procedureIDRootPath, defaultAllocStep), dispatch, procedureStorage)
+	procedureFactory := coordinator.NewFactory(logger, id.NewAllocatorImpl(logger, client, procedureIDRootPath, defaultAllocStep), dispatch, procedureStorage, metadata)
 
 	schedulerManager := manager.NewManager(logger, procedureManager, procedureFactory, metadata, client, rootPath, metadata.GetTopologyType(), metadata.GetProcedureExecutingBatchSize())
 

--- a/server/cluster/metadata/cluster_metadata.go
+++ b/server/cluster/metadata/cluster_metadata.go
@@ -282,7 +282,7 @@ func (c *ClusterMetadata) GetTable(schemaName, tableName string) (storage.Table,
 
 // GetTableShard get the shard where the table actually exists.
 func (c *ClusterMetadata) GetTableShard(ctx context.Context, table storage.Table) (storage.ShardID, bool) {
-	return c.topologyManager.GetTableShard(ctx, table)
+	return c.topologyManager.GetTableShardID(ctx, table)
 }
 
 func (c *ClusterMetadata) CreateTableMetadata(ctx context.Context, request CreateTableMetadataRequest) (CreateTableMetadataResult, error) {
@@ -403,7 +403,7 @@ func (c *ClusterMetadata) GetAssignTable(ctx context.Context, schemaName string,
 	if !exists {
 		return 0, false, errors.WithMessagef(ErrSchemaNotFound, "schema %s not found", schemaName)
 	}
-	shardIDs, exists := c.topologyManager.GetAssignTableResult(ctx, schema.ID, tableName)
+	shardIDs, exists := c.topologyManager.GetAssignTableShard(ctx, schema.ID, tableName)
 	return shardIDs, exists, nil
 }
 
@@ -412,7 +412,7 @@ func (c *ClusterMetadata) AssignTable(ctx context.Context, schemaName string, ta
 	if !exists {
 		return errors.WithMessagef(ErrSchemaNotFound, "schema %s not found", schemaName)
 	}
-	return c.topologyManager.AssignTable(ctx, schema.ID, tableName, shardID)
+	return c.topologyManager.AssignTableToShard(ctx, schema.ID, tableName, shardID)
 }
 
 func (c *ClusterMetadata) DeleteAssignTable(ctx context.Context, schemaName string, tableName string) error {
@@ -420,7 +420,7 @@ func (c *ClusterMetadata) DeleteAssignTable(ctx context.Context, schemaName stri
 	if !exists {
 		return errors.WithMessagef(ErrSchemaNotFound, "schema %s not found", schemaName)
 	}
-	return c.topologyManager.DeleteAssignTable(ctx, schema.ID, tableName)
+	return c.topologyManager.DeleteTableAssignedShard(ctx, schema.ID, tableName)
 }
 
 func (c *ClusterMetadata) GetShards() []storage.ShardID {

--- a/server/cluster/metadata/cluster_metadata.go
+++ b/server/cluster/metadata/cluster_metadata.go
@@ -115,7 +115,8 @@ func (c *ClusterMetadata) Load(ctx context.Context) error {
 		return errors.WithMessage(err, "load table manager")
 	}
 
-	if err := c.topologyManager.Load(ctx); err != nil {
+	schemas := c.tableManager.GetSchemas()
+	if err := c.topologyManager.Load(ctx, schemas); err != nil {
 		return errors.WithMessage(err, "load topology manager")
 	}
 
@@ -390,6 +391,18 @@ func (c *ClusterMetadata) CreateTable(ctx context.Context, request CreateTableRe
 	}
 	c.logger.Info("create table succeed", zap.String("cluster", c.Name()), zap.String("result", fmt.Sprintf("%+v", ret)))
 	return ret, nil
+}
+
+func (c *ClusterMetadata) GetAssignTable(ctx context.Context, schemaID storage.SchemaID, tableName string) (storage.ShardID, bool) {
+	return c.topologyManager.GetAssignTableResult(ctx, schemaID, tableName)
+}
+
+func (c *ClusterMetadata) AssignTable(ctx context.Context, schemaID storage.SchemaID, tableName string, shardID storage.ShardID) error {
+	return c.topologyManager.AssignTable(ctx, schemaID, tableName, shardID)
+}
+
+func (c *ClusterMetadata) DeleteAssignTable(ctx context.Context, schemaID storage.SchemaID, tableName string) error {
+	return c.topologyManager.DeleteAssignTable(ctx, schemaID, tableName)
 }
 
 func (c *ClusterMetadata) GetShards() []storage.ShardID {

--- a/server/cluster/metadata/cluster_metadata.go
+++ b/server/cluster/metadata/cluster_metadata.go
@@ -398,16 +398,16 @@ func (c *ClusterMetadata) CreateTable(ctx context.Context, request CreateTableRe
 	return ret, nil
 }
 
-func (c *ClusterMetadata) GetAssignTable(ctx context.Context, schemaName string, tableName string) (storage.ShardID, bool, error) {
+func (c *ClusterMetadata) GetTableAssignedShard(ctx context.Context, schemaName string, tableName string) (storage.ShardID, bool, error) {
 	schema, exists := c.tableManager.GetSchema(schemaName)
 	if !exists {
 		return 0, false, errors.WithMessagef(ErrSchemaNotFound, "schema %s not found", schemaName)
 	}
-	shardIDs, exists := c.topologyManager.GetAssignTableShard(ctx, schema.ID, tableName)
+	shardIDs, exists := c.topologyManager.GetTableAssignedShard(ctx, schema.ID, tableName)
 	return shardIDs, exists, nil
 }
 
-func (c *ClusterMetadata) AssignTable(ctx context.Context, schemaName string, tableName string, shardID storage.ShardID) error {
+func (c *ClusterMetadata) AssignTableToShard(ctx context.Context, schemaName string, tableName string, shardID storage.ShardID) error {
 	schema, exists := c.tableManager.GetSchema(schemaName)
 	if !exists {
 		return errors.WithMessagef(ErrSchemaNotFound, "schema %s not found", schemaName)
@@ -415,7 +415,7 @@ func (c *ClusterMetadata) AssignTable(ctx context.Context, schemaName string, ta
 	return c.topologyManager.AssignTableToShard(ctx, schema.ID, tableName, shardID)
 }
 
-func (c *ClusterMetadata) DeleteAssignTable(ctx context.Context, schemaName string, tableName string) error {
+func (c *ClusterMetadata) DeleteTableAssignedShard(ctx context.Context, schemaName string, tableName string) error {
 	schema, exists := c.tableManager.GetSchema(schemaName)
 	if !exists {
 		return errors.WithMessagef(ErrSchemaNotFound, "schema %s not found", schemaName)

--- a/server/cluster/metadata/cluster_metadata.go
+++ b/server/cluster/metadata/cluster_metadata.go
@@ -393,8 +393,12 @@ func (c *ClusterMetadata) CreateTable(ctx context.Context, request CreateTableRe
 	return ret, nil
 }
 
-func (c *ClusterMetadata) GetAssignTable(ctx context.Context, schemaID storage.SchemaID, tableName string) (storage.ShardID, bool) {
-	return c.topologyManager.GetAssignTableResult(ctx, schemaID, tableName)
+func (c *ClusterMetadata) GetAssignTable(ctx context.Context, schemaName string, tableName string) (storage.ShardID, bool) {
+	schema, exists := c.tableManager.GetSchema(schemaName)
+	if !exists {
+		return 0, false
+	}
+	return c.topologyManager.GetAssignTableResult(ctx, schema.ID, tableName)
 }
 
 func (c *ClusterMetadata) AssignTable(ctx context.Context, schemaID storage.SchemaID, tableName string, shardID storage.ShardID) error {

--- a/server/cluster/metadata/topology_manager.go
+++ b/server/cluster/metadata/topology_manager.go
@@ -667,7 +667,6 @@ func (m *TopologyManagerImpl) loadAssignTable(ctx context.Context, schemas []sto
 		if err != nil {
 			return errors.WithMessage(err, "storage list assign table")
 		}
-		//m.tableAssignMapping[schema.ID] = make(map[string]storage.ShardID, len(listAssignTableResult.TableAssigns))
 		for _, assignTable := range listAssignTableResult.TableAssigns {
 			m.tableAssignMapping[schema.ID][assignTable.TableName] = assignTable.ShardID
 		}

--- a/server/cluster/metadata/topology_manager.go
+++ b/server/cluster/metadata/topology_manager.go
@@ -45,13 +45,13 @@ type TopologyManager interface {
 	// RemoveTable remove table on target shards from cluster topology.
 	RemoveTable(ctx context.Context, shardID storage.ShardID, latestVersion uint64, tableIDs []storage.TableID) error
 	// GetTableShard get the shardID of the shard where the table is located.
-	GetTableShard(ctx context.Context, table storage.Table) (storage.ShardID, bool)
+	GetTableShardID(ctx context.Context, table storage.Table) (storage.ShardID, bool)
 	// AssignTable persistent table shard mapping, it is used to store assign results and make the table creation idempotent.
-	AssignTable(ctx context.Context, schemaID storage.SchemaID, tableName string, shardID storage.ShardID) error
+	AssignTableToShard(ctx context.Context, schemaID storage.SchemaID, tableName string, shardID storage.ShardID) error
 	// GetAssignTableResult get table assign result.
-	GetAssignTableResult(ctx context.Context, schemaID storage.SchemaID, tableName string) (storage.ShardID, bool)
+	GetAssignTableShard(ctx context.Context, schemaID storage.SchemaID, tableName string) (storage.ShardID, bool)
 	// DeleteAssignTable delete table assign result.
-	DeleteAssignTable(ctx context.Context, schemaID storage.SchemaID, tableName string) error
+	DeleteTableAssignedShard(ctx context.Context, schemaID storage.SchemaID, tableName string) error
 	// GetShards get all shards in cluster topology.
 	GetShards() []storage.ShardID
 	// GetShardNodesByID get shardNodes with shardID.
@@ -310,7 +310,7 @@ func (m *TopologyManagerImpl) RemoveTable(ctx context.Context, shardID storage.S
 	return nil
 }
 
-func (m *TopologyManagerImpl) GetTableShard(_ context.Context, table storage.Table) (storage.ShardID, bool) {
+func (m *TopologyManagerImpl) GetTableShardID(_ context.Context, table storage.Table) (storage.ShardID, bool) {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 
@@ -322,7 +322,7 @@ func (m *TopologyManagerImpl) GetTableShard(_ context.Context, table storage.Tab
 	return 0, false
 }
 
-func (m *TopologyManagerImpl) AssignTable(ctx context.Context, schemaID storage.SchemaID, tableName string, shardID storage.ShardID) error {
+func (m *TopologyManagerImpl) AssignTableToShard(ctx context.Context, schemaID storage.SchemaID, tableName string, shardID storage.ShardID) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
@@ -345,12 +345,12 @@ func (m *TopologyManagerImpl) AssignTable(ctx context.Context, schemaID storage.
 	return nil
 }
 
-func (m *TopologyManagerImpl) GetAssignTableResult(_ context.Context, schemaID storage.SchemaID, tableName string) (storage.ShardID, bool) {
+func (m *TopologyManagerImpl) GetAssignTableShard(_ context.Context, schemaID storage.SchemaID, tableName string) (storage.ShardID, bool) {
 	assignResult, exists := m.tableAssignMapping[schemaID][tableName]
 	return assignResult, exists
 }
 
-func (m *TopologyManagerImpl) DeleteAssignTable(ctx context.Context, schemaID storage.SchemaID, tableName string) error {
+func (m *TopologyManagerImpl) DeleteTableAssignedShard(ctx context.Context, schemaID storage.SchemaID, tableName string) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 

--- a/server/coordinator/factory.go
+++ b/server/coordinator/factory.go
@@ -130,7 +130,10 @@ func (f *Factory) makeCreateTableProcedure(ctx context.Context, request CreateTa
 	snapshot := request.ClusterMetadata.GetClusterSnapshot()
 
 	var targetShardID storage.ShardID
-	shardID, exists := request.ClusterMetadata.GetAssignTable(ctx, request.SourceReq.SchemaName, request.SourceReq.Name)
+	shardID, exists, err := request.ClusterMetadata.GetAssignTable(ctx, request.SourceReq.SchemaName, request.SourceReq.Name)
+	if err != nil {
+		return nil, err
+	}
 	if exists {
 		targetShardID = shardID
 	} else {

--- a/server/coordinator/factory.go
+++ b/server/coordinator/factory.go
@@ -39,12 +39,11 @@ import (
 )
 
 type Factory struct {
-	logger          *zap.Logger
-	idAllocator     id.Allocator
-	dispatch        eventdispatch.Dispatch
-	storage         procedure.Storage
-	shardPicker     *PersistShardPicker
-	clusterMetadata *metadata.ClusterMetadata
+	logger      *zap.Logger
+	idAllocator id.Allocator
+	dispatch    eventdispatch.Dispatch
+	storage     procedure.Storage
+	shardPicker *PersistShardPicker
 }
 
 type CreateTableRequest struct {

--- a/server/coordinator/factory.go
+++ b/server/coordinator/factory.go
@@ -130,7 +130,7 @@ func (f *Factory) makeCreateTableProcedure(ctx context.Context, request CreateTa
 	snapshot := request.ClusterMetadata.GetClusterSnapshot()
 
 	var targetShardID storage.ShardID
-	shardID, exists, err := request.ClusterMetadata.GetAssignTable(ctx, request.SourceReq.SchemaName, request.SourceReq.Name)
+	shardID, exists, err := request.ClusterMetadata.GetTableAssignedShard(ctx, request.SourceReq.SchemaName, request.SourceReq.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/server/coordinator/factory_test.go
+++ b/server/coordinator/factory_test.go
@@ -39,7 +39,7 @@ func setupFactory(t *testing.T) (*coordinator.Factory, *metadata.ClusterMetadata
 	dispatch := test.MockDispatch{}
 	allocator := test.MockIDAllocator{}
 	storage := test.NewTestStorage(t)
-	f := coordinator.NewFactory(zap.NewNop(), allocator, dispatch, storage)
+	f := coordinator.NewFactory(zap.NewNop(), allocator, dispatch, storage, c.GetMetadata())
 
 	return f, c.GetMetadata()
 }

--- a/server/coordinator/persist_shard_picker.go
+++ b/server/coordinator/persist_shard_picker.go
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package coordinator
 
 import (

--- a/server/coordinator/persist_shard_picker.go
+++ b/server/coordinator/persist_shard_picker.go
@@ -1,0 +1,62 @@
+package coordinator
+
+import (
+	"context"
+	"github.com/apache/incubator-horaedb-meta/server/cluster/metadata"
+	"github.com/apache/incubator-horaedb-meta/server/storage"
+	"github.com/pkg/errors"
+)
+
+type PersistShardPicker struct {
+	cluster  *metadata.ClusterMetadata
+	internal ShardPicker
+}
+
+func NewPersistShardPicker(cluster *metadata.ClusterMetadata, internal ShardPicker) *PersistShardPicker {
+	return &PersistShardPicker{cluster: cluster, internal: internal}
+}
+
+func (p *PersistShardPicker) PickShards(ctx context.Context, snapshot metadata.Snapshot, schemaName string, tableNames []string) (map[string]storage.ShardNode, error) {
+	result := map[string]storage.ShardNode{}
+
+	shardNodeMap := map[storage.ShardID]storage.ShardNode{}
+	for _, shardNode := range snapshot.Topology.ClusterView.ShardNodes {
+		shardNodeMap[shardNode.ID] = shardNode
+	}
+
+	// If table assign has been created, just reuse it.
+	for i := 0; i < len(tableNames); i++ {
+		shardID, exists, err := p.cluster.GetAssignTable(ctx, schemaName, tableNames[i])
+		if err != nil {
+			return map[string]storage.ShardNode{}, err
+		}
+		if exists {
+			result[tableNames[i]] = shardNodeMap[shardID]
+		}
+	}
+
+	if len(result) == len(tableNames) {
+		return result, nil
+	}
+
+	if len(result) != len(tableNames) && len(result) != 0 {
+		// TODO: Should all table assigns be cleared?
+		return result, errors.WithMessagef(ErrPickNode, "The number of table assign %d is inconsistent with the number of tables %d", len(result), len(tableNames))
+	}
+
+	// No table assign has been created, try to pick shard and save table assigns.
+	shardNodes, err := p.internal.PickShards(ctx, snapshot, len(tableNames))
+	if err != nil {
+		return map[string]storage.ShardNode{}, err
+	}
+
+	for i, shardNode := range shardNodes {
+		result[tableNames[i]] = shardNode
+		err = p.cluster.AssignTable(ctx, schemaName, tableNames[i], shardNode.ID)
+		if err != nil {
+			return map[string]storage.ShardNode{}, err
+		}
+	}
+
+	return result, nil
+}

--- a/server/coordinator/persist_shard_picker.go
+++ b/server/coordinator/persist_shard_picker.go
@@ -2,6 +2,7 @@ package coordinator
 
 import (
 	"context"
+
 	"github.com/apache/incubator-horaedb-meta/server/cluster/metadata"
 	"github.com/apache/incubator-horaedb-meta/server/storage"
 	"github.com/pkg/errors"

--- a/server/coordinator/persist_shard_picker_test.go
+++ b/server/coordinator/persist_shard_picker_test.go
@@ -1,0 +1,67 @@
+package coordinator_test
+
+import (
+	"context"
+	"github.com/apache/incubator-horaedb-meta/server/cluster/metadata"
+	"github.com/apache/incubator-horaedb-meta/server/coordinator"
+	"github.com/apache/incubator-horaedb-meta/server/coordinator/procedure/test"
+	"github.com/apache/incubator-horaedb-meta/server/storage"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestPersistShardPicker(t *testing.T) {
+	re := require.New(t)
+	ctx := context.Background()
+
+	c := test.InitStableCluster(ctx, t)
+
+	persistShardPicker := coordinator.NewPersistShardPicker(c.GetMetadata(), coordinator.NewLeastTableShardPicker())
+	pickResult, err := persistShardPicker.PickShards(ctx, c.GetMetadata().GetClusterSnapshot(), test.TestSchemaName, []string{test.TestTableName0})
+	re.NoError(err)
+	re.Equal(len(pickResult), 1)
+
+	createResult, err := c.GetMetadata().CreateTable(ctx, metadata.CreateTableRequest{
+		ShardID:       pickResult[test.TestTableName0].ID,
+		LatestVersion: 0,
+		SchemaName:    test.TestSchemaName,
+		TableName:     test.TestTableName0,
+		PartitionInfo: storage.PartitionInfo{Info: nil},
+	})
+	re.NoError(err)
+	re.Equal(test.TestTableName0, createResult.Table.Name)
+
+	// Try to pick shard for same table after the table is created.
+	newPickResult, err := persistShardPicker.PickShards(ctx, c.GetMetadata().GetClusterSnapshot(), test.TestSchemaName, []string{test.TestTableName0})
+	re.NoError(err)
+	re.Equal(len(newPickResult), 1)
+	re.Equal(newPickResult[test.TestTableName0], pickResult[test.TestTableName0])
+
+	// Try to pick shard for another table.
+	pickResult, err = persistShardPicker.PickShards(ctx, c.GetMetadata().GetClusterSnapshot(), test.TestSchemaName, []string{test.TestTableName1})
+	re.NoError(err)
+	re.Equal(len(pickResult), 1)
+
+	err = c.GetMetadata().DropTable(ctx, metadata.DropTableRequest{
+		SchemaName:    test.TestSchemaName,
+		TableName:     test.TestTableName0,
+		ShardID:       pickResult[test.TestTableName0].ID,
+		LatestVersion: 0,
+	})
+	re.NoError(err)
+
+	// Try to pick shard for table1 after drop table0.
+	newPickResult, err = persistShardPicker.PickShards(ctx, c.GetMetadata().GetClusterSnapshot(), test.TestSchemaName, []string{test.TestTableName1})
+	re.NoError(err)
+	re.Equal(len(pickResult), 1)
+	re.Equal(newPickResult[test.TestTableName1], pickResult[test.TestTableName1])
+
+	err = c.GetMetadata().DeleteAssignTable(ctx, test.TestSchemaName, test.TestTableName1)
+	re.NoError(err)
+
+	// Try to pick another for table1 after drop table1 assign result.
+	newPickResult, err = persistShardPicker.PickShards(ctx, c.GetMetadata().GetClusterSnapshot(), test.TestSchemaName, []string{test.TestTableName1})
+	re.NoError(err)
+	re.Equal(len(pickResult), 1)
+	re.NotEqual(newPickResult[test.TestTableName1], pickResult[test.TestTableName1])
+}

--- a/server/coordinator/persist_shard_picker_test.go
+++ b/server/coordinator/persist_shard_picker_test.go
@@ -2,12 +2,13 @@ package coordinator_test
 
 import (
 	"context"
+	"testing"
+
 	"github.com/apache/incubator-horaedb-meta/server/cluster/metadata"
 	"github.com/apache/incubator-horaedb-meta/server/coordinator"
 	"github.com/apache/incubator-horaedb-meta/server/coordinator/procedure/test"
 	"github.com/apache/incubator-horaedb-meta/server/storage"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestPersistShardPicker(t *testing.T) {

--- a/server/coordinator/persist_shard_picker_test.go
+++ b/server/coordinator/persist_shard_picker_test.go
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package coordinator_test
 
 import (

--- a/server/coordinator/persist_shard_picker_test.go
+++ b/server/coordinator/persist_shard_picker_test.go
@@ -76,7 +76,7 @@ func TestPersistShardPicker(t *testing.T) {
 	re.Equal(len(pickResult), 1)
 	re.Equal(newPickResult[test.TestTableName1], pickResult[test.TestTableName1])
 
-	err = c.GetMetadata().DeleteAssignTable(ctx, test.TestSchemaName, test.TestTableName1)
+	err = c.GetMetadata().DeleteTableAssignedShard(ctx, test.TestSchemaName, test.TestTableName1)
 	re.NoError(err)
 
 	// Try to pick another for table1 after drop table1 assign result.

--- a/server/coordinator/procedure/ddl/createtable/create_table.go
+++ b/server/coordinator/procedure/ddl/createtable/create_table.go
@@ -37,36 +37,112 @@ import (
 )
 
 const (
-	eventCreateMetadata = "EventCreateMetadata"
-	eventCreateOnShard  = "EventCreateOnShard"
-	eventFinish         = "EventFinish"
+	eventCheckTableExists  = "EventCheckTableExists"
+	eventCreateTableAssign = "EventCreateTableAssign"
+	eventCreateMetadata    = "EventCreateMetadata"
+	eventCreateOnShard     = "EventCreateOnShard"
+	eventFinish            = "EventFinish"
 
-	stateBegin          = "StateBegin"
-	stateCreateMetadata = "StateCreateMetadata"
-	stateCreateOnShard  = "StateCreateOnShard"
-	stateFinish         = "StateFinish"
+	stateBegin             = "StateBegin"
+	stateCheckTableExists  = "StateCheckTableExists"
+	stateCreateTableAssign = "StateCreateTableAssign"
+	stateCreateMetadata    = "StateCreateMetadata"
+	stateCreateOnShard     = "StateCreateOnShard"
+	stateFinish            = "StateFinish"
 )
 
 var (
 	createTableEvents = fsm.Events{
-		{Name: eventCreateMetadata, Src: []string{stateBegin}, Dst: stateCreateMetadata},
+		{Name: eventCheckTableExists, Src: []string{stateBegin}, Dst: stateCheckTableExists},
+		{Name: eventCreateTableAssign, Src: []string{stateCheckTableExists}, Dst: stateCreateTableAssign},
+		{Name: eventCreateMetadata, Src: []string{stateCreateTableAssign}, Dst: stateCreateMetadata},
 		{Name: eventCreateOnShard, Src: []string{stateCreateMetadata}, Dst: stateCreateOnShard},
 		{Name: eventFinish, Src: []string{stateCreateOnShard}, Dst: stateFinish},
 	}
 	createTableCallbacks = fsm.Callbacks{
-		eventCreateMetadata: createMetadataCallback,
-		eventCreateOnShard:  createOnShard,
-		eventFinish:         createFinish,
+		eventCheckTableExists:  checkTableExists,
+		eventCreateTableAssign: createTableAssign,
+		eventCreateMetadata:    createMetadata,
+		eventCreateOnShard:     createOnShard,
+		eventFinish:            createFinish,
 	}
 )
 
-func createMetadataCallback(event *fsm.Event) {
+func checkTableExists(event *fsm.Event) {
 	req, err := procedure.GetRequestFromEvent[*callbackRequest](event)
 	if err != nil {
 		procedure.CancelEventWithLog(event, err, "get request from event")
 		return
 	}
 	params := req.p.params
+
+	// Check whether the table metadata already exists.
+	table, exists, err := params.ClusterMetadata.GetTable(params.SourceReq.GetSchemaName(), params.SourceReq.GetName())
+	if err != nil {
+		procedure.CancelEventWithLog(event, err, "get table metadata")
+		return
+	}
+	if !exists {
+		return
+	}
+
+	// Check whether the table shard mapping already exists.
+	_, exists = params.ClusterMetadata.GetTableShard(req.ctx, table)
+	if exists {
+		procedure.CancelEventWithLog(event, metadata.ErrTableAlreadyExists, "table already exists")
+		return
+	}
+}
+
+func createTableAssign(event *fsm.Event) {
+	req, err := procedure.GetRequestFromEvent[*callbackRequest](event)
+	if err != nil {
+		procedure.CancelEventWithLog(event, err, "get request from event")
+		return
+	}
+	params := req.p.params
+
+	schemaName := params.SourceReq.GetSchemaName()
+	tableName := params.SourceReq.GetName()
+
+	targetShardID, exists, err := params.ClusterMetadata.GetAssignTable(req.ctx, schemaName, tableName)
+	if err != nil {
+		procedure.CancelEventWithLog(event, err, "get table assign", zap.String("schemaName", schemaName), zap.String("tableName", tableName))
+		return
+	}
+	if exists {
+		if targetShardID != params.ShardID {
+			procedure.CancelEventWithLog(event, procedure.ErrShardNotMatch, "target shard not match to persist data", zap.String("schemaName", schemaName), zap.String("tableName", tableName), zap.Uint32("targetShardID", uint32(targetShardID)), zap.Uint32("persistShardID", uint32(params.ShardID)))
+			return
+		}
+		return
+	}
+
+	if err := params.ClusterMetadata.AssignTable(req.ctx, schemaName, tableName, params.ShardID); err != nil {
+		procedure.CancelEventWithLog(event, err, "persist table assign")
+		return
+	}
+
+	log.Debug("create table assign finish", zap.String("schemaName", schemaName), zap.String("tableName", tableName))
+}
+
+func createMetadata(event *fsm.Event) {
+	req, err := procedure.GetRequestFromEvent[*callbackRequest](event)
+	if err != nil {
+		procedure.CancelEventWithLog(event, err, "get request from event")
+		return
+	}
+	params := req.p.params
+
+	_, exists, err := params.ClusterMetadata.GetTable(params.SourceReq.GetSchemaName(), params.SourceReq.GetName())
+	if err != nil {
+		procedure.CancelEventWithLog(event, err, "get table metadata")
+		return
+	}
+	if exists {
+		log.Info("table metadata already exists", zap.String("schemaName", params.SourceReq.GetSchemaName()), zap.String("tableName", params.SourceReq.GetName()))
+		return
+	}
 
 	createTableMetadataRequest := metadata.CreateTableMetadataRequest{
 		SchemaName:    params.SourceReq.GetSchemaName(),
@@ -138,6 +214,11 @@ func createFinish(event *fsm.Event) {
 	if err != nil {
 		procedure.CancelEventWithLog(event, err, "get request from event")
 		return
+	}
+	params := req.p.params
+
+	if err := req.p.params.ClusterMetadata.DeleteAssignTable(req.ctx, params.SourceReq.GetSchemaName(), params.SourceReq.GetName()); err != nil {
+		log.Warn("delete assign table failed", zap.String("schemaName", params.SourceReq.GetSchemaName()), zap.String("tableName", params.SourceReq.GetName()))
 	}
 
 	assert.Assert(req.createTableResult != nil)
@@ -229,7 +310,6 @@ func (p *Procedure) Kind() procedure.Kind {
 func (p *Procedure) Start(ctx context.Context) error {
 	p.updateState(procedure.StateRunning)
 
-	// Try to load persist data.
 	req := &callbackRequest{
 		ctx:               ctx,
 		p:                 p,
@@ -239,6 +319,16 @@ func (p *Procedure) Start(ctx context.Context) error {
 	for {
 		switch p.fsm.Current() {
 		case stateBegin:
+			if err := p.fsm.Event(eventCheckTableExists, req); err != nil {
+				_ = p.params.OnFailed(err)
+				return err
+			}
+		case stateCheckTableExists:
+			if err := p.fsm.Event(eventCreateTableAssign, req); err != nil {
+				_ = p.params.OnFailed(err)
+				return err
+			}
+		case stateCreateTableAssign:
 			if err := p.fsm.Event(eventCreateMetadata, req); err != nil {
 				_ = p.params.OnFailed(err)
 				return err

--- a/server/coordinator/procedure/ddl/createtable/create_table.go
+++ b/server/coordinator/procedure/ddl/createtable/create_table.go
@@ -181,7 +181,7 @@ func createFinish(event *fsm.Event) {
 	}
 	params := req.p.params
 
-	if err := req.p.params.ClusterMetadata.DeleteAssignTable(req.ctx, params.SourceReq.GetSchemaName(), params.SourceReq.GetName()); err != nil {
+	if err := req.p.params.ClusterMetadata.DeleteTableAssignedShard(req.ctx, params.SourceReq.GetSchemaName(), params.SourceReq.GetName()); err != nil {
 		log.Warn("delete assign table failed", zap.String("schemaName", params.SourceReq.GetSchemaName()), zap.String("tableName", params.SourceReq.GetName()))
 	}
 

--- a/server/coordinator/procedure/ddl/createtable/create_table.go
+++ b/server/coordinator/procedure/ddl/createtable/create_table.go
@@ -85,7 +85,7 @@ func checkTableExists(event *fsm.Event) {
 	// Check whether the table shard mapping already exists.
 	_, exists = params.ClusterMetadata.GetTableShard(req.ctx, table)
 	if exists {
-		procedure.CancelEventWithLog(event, metadata.ErrTableAlreadyExists, "table already exists")
+		procedure.CancelEventWithLog(event, metadata.ErrTableAlreadyExists, "table shard already exists")
 		return
 	}
 }

--- a/server/coordinator/procedure/error.go
+++ b/server/coordinator/procedure/error.go
@@ -23,6 +23,7 @@ import "github.com/apache/incubator-horaedb-meta/pkg/coderr"
 
 var (
 	ErrShardLeaderNotFound     = coderr.NewCodeError(coderr.Internal, "shard leader not found")
+	ErrShardNotMatch           = coderr.NewCodeError(coderr.Internal, "target shard not match to persis data")
 	ErrProcedureNotFound       = coderr.NewCodeError(coderr.Internal, "procedure not found")
 	ErrClusterConfigChanged    = coderr.NewCodeError(coderr.Internal, "cluster config changed")
 	ErrTableNotExists          = coderr.NewCodeError(coderr.Internal, "table not exists")

--- a/server/coordinator/procedure/storage_impl.go
+++ b/server/coordinator/procedure/storage_impl.go
@@ -1,20 +1,17 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Copyright 2022 The CeresDB Authors
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package procedure
@@ -27,8 +24,8 @@ import (
 	"path"
 	"strconv"
 
-	"github.com/apache/incubator-horaedb-meta/pkg/log"
-	"github.com/apache/incubator-horaedb-meta/server/etcdutil"
+	"github.com/CeresDB/ceresmeta/pkg/log"
+	"github.com/CeresDB/ceresmeta/server/etcdutil"
 	"github.com/pkg/errors"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/clientv3util"

--- a/server/coordinator/procedure/storage_impl.go
+++ b/server/coordinator/procedure/storage_impl.go
@@ -1,17 +1,20 @@
 /*
- * Copyright 2022 The CeresDB Authors
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package procedure
@@ -24,8 +27,8 @@ import (
 	"path"
 	"strconv"
 
-	"github.com/CeresDB/ceresmeta/pkg/log"
-	"github.com/CeresDB/ceresmeta/server/etcdutil"
+	"github.com/apache/incubator-horaedb-meta/pkg/log"
+	"github.com/apache/incubator-horaedb-meta/server/etcdutil"
 	"github.com/pkg/errors"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/clientv3util"

--- a/server/coordinator/scheduler/manager/scheduler_manager_test.go
+++ b/server/coordinator/scheduler/manager/scheduler_manager_test.go
@@ -44,7 +44,7 @@ func TestSchedulerManager(t *testing.T) {
 	dispatch := test.MockDispatch{}
 	allocator := test.MockIDAllocator{}
 	s := test.NewTestStorage(t)
-	f := coordinator.NewFactory(zap.NewNop(), allocator, dispatch, s)
+	f := coordinator.NewFactory(zap.NewNop(), allocator, dispatch, s, c.GetMetadata())
 	_, client, _ := etcdutil.PrepareEtcdServerAndClient(t)
 
 	// Create scheduler manager with enableScheduler equal to false.

--- a/server/coordinator/scheduler/rebalanced/scheduler_test.go
+++ b/server/coordinator/scheduler/rebalanced/scheduler_test.go
@@ -35,23 +35,25 @@ func TestRebalancedScheduler(t *testing.T) {
 	re := require.New(t)
 	ctx := context.Background()
 
-	procedureFactory := coordinator.NewFactory(zap.NewNop(), test.MockIDAllocator{}, test.MockDispatch{}, test.NewTestStorage(t))
-
-	s := rebalanced.NewShardScheduler(zap.NewNop(), procedureFactory, nodepicker.NewConsistentUniformHashNodePicker(zap.NewNop()), 1)
-
 	// EmptyCluster would be scheduled an empty procedure.
 	emptyCluster := test.InitEmptyCluster(ctx, t)
+	procedureFactory := coordinator.NewFactory(zap.NewNop(), test.MockIDAllocator{}, test.MockDispatch{}, test.NewTestStorage(t), emptyCluster.GetMetadata())
+	s := rebalanced.NewShardScheduler(zap.NewNop(), procedureFactory, nodepicker.NewConsistentUniformHashNodePicker(zap.NewNop()), 1)
 	result, err := s.Schedule(ctx, emptyCluster.GetMetadata().GetClusterSnapshot())
 	re.NoError(err)
 	re.Empty(result)
 
 	// PrepareCluster would be scheduled an empty procedure.
 	prepareCluster := test.InitPrepareCluster(ctx, t)
+	procedureFactory = coordinator.NewFactory(zap.NewNop(), test.MockIDAllocator{}, test.MockDispatch{}, test.NewTestStorage(t), prepareCluster.GetMetadata())
+	s = rebalanced.NewShardScheduler(zap.NewNop(), procedureFactory, nodepicker.NewConsistentUniformHashNodePicker(zap.NewNop()), 1)
 	_, err = s.Schedule(ctx, prepareCluster.GetMetadata().GetClusterSnapshot())
 	re.NoError(err)
 
 	// StableCluster with all shards assigned would be scheduled a load balance procedure.
 	stableCluster := test.InitStableCluster(ctx, t)
+	procedureFactory = coordinator.NewFactory(zap.NewNop(), test.MockIDAllocator{}, test.MockDispatch{}, test.NewTestStorage(t), stableCluster.GetMetadata())
+	s = rebalanced.NewShardScheduler(zap.NewNop(), procedureFactory, nodepicker.NewConsistentUniformHashNodePicker(zap.NewNop()), 1)
 	_, err = s.Schedule(ctx, stableCluster.GetMetadata().GetClusterSnapshot())
 	re.NoError(err)
 }

--- a/server/coordinator/scheduler/reopen/scheduler_test.go
+++ b/server/coordinator/scheduler/reopen/scheduler_test.go
@@ -35,12 +35,12 @@ import (
 func TestReopenShardScheduler(t *testing.T) {
 	re := require.New(t)
 	ctx := context.Background()
+	emptyCluster := test.InitEmptyCluster(ctx, t)
 
-	procedureFactory := coordinator.NewFactory(zap.NewNop(), test.MockIDAllocator{}, test.MockDispatch{}, test.NewTestStorage(t))
+	procedureFactory := coordinator.NewFactory(zap.NewNop(), test.MockIDAllocator{}, test.MockDispatch{}, test.NewTestStorage(t), emptyCluster.GetMetadata())
 
 	s := reopen.NewShardScheduler(procedureFactory, 1)
 
-	emptyCluster := test.InitEmptyCluster(ctx, t)
 	// ReopenShardScheduler should not schedule when cluster is not stable.
 	result, err := s.Schedule(ctx, emptyCluster.GetMetadata().GetClusterSnapshot())
 	re.NoError(err)

--- a/server/coordinator/scheduler/static/scheduler_test.go
+++ b/server/coordinator/scheduler/static/scheduler_test.go
@@ -35,24 +35,26 @@ func TestStaticTopologyScheduler(t *testing.T) {
 	re := require.New(t)
 	ctx := context.Background()
 
-	procedureFactory := coordinator.NewFactory(zap.NewNop(), test.MockIDAllocator{}, test.MockDispatch{}, test.NewTestStorage(t))
-
-	s := static.NewShardScheduler(procedureFactory, nodepicker.NewConsistentUniformHashNodePicker(zap.NewNop()), 1)
-
 	// EmptyCluster would be scheduled an empty procedure.
 	emptyCluster := test.InitEmptyCluster(ctx, t)
+	procedureFactory := coordinator.NewFactory(zap.NewNop(), test.MockIDAllocator{}, test.MockDispatch{}, test.NewTestStorage(t), emptyCluster.GetMetadata())
+	s := static.NewShardScheduler(procedureFactory, nodepicker.NewConsistentUniformHashNodePicker(zap.NewNop()), 1)
 	result, err := s.Schedule(ctx, emptyCluster.GetMetadata().GetClusterSnapshot())
 	re.NoError(err)
 	re.Empty(result)
 
 	// PrepareCluster would be scheduled a transfer leader procedure.
 	prepareCluster := test.InitPrepareCluster(ctx, t)
+	procedureFactory = coordinator.NewFactory(zap.NewNop(), test.MockIDAllocator{}, test.MockDispatch{}, test.NewTestStorage(t), prepareCluster.GetMetadata())
+	s = static.NewShardScheduler(procedureFactory, nodepicker.NewConsistentUniformHashNodePicker(zap.NewNop()), 1)
 	result, err = s.Schedule(ctx, prepareCluster.GetMetadata().GetClusterSnapshot())
 	re.NoError(err)
 	re.NotEmpty(result)
 
 	// StableCluster with all shards assigned would be scheduled a transfer leader procedure by hash rule.
 	stableCluster := test.InitStableCluster(ctx, t)
+	procedureFactory = coordinator.NewFactory(zap.NewNop(), test.MockIDAllocator{}, test.MockDispatch{}, test.NewTestStorage(t), stableCluster.GetMetadata())
+	s = static.NewShardScheduler(procedureFactory, nodepicker.NewConsistentUniformHashNodePicker(zap.NewNop()), 1)
 	result, err = s.Schedule(ctx, stableCluster.GetMetadata().GetClusterSnapshot())
 	re.NoError(err)
 	re.NotEmpty(result)

--- a/server/etcdutil/util.go
+++ b/server/etcdutil/util.go
@@ -19,10 +19,11 @@ package etcdutil
 
 import (
 	"context"
+	"path"
+
 	"github.com/CeresDB/ceresmeta/pkg/log"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
-	"path"
 )
 
 func Get(ctx context.Context, client *clientv3.Client, key string) (string, error) {

--- a/server/etcdutil/util.go
+++ b/server/etcdutil/util.go
@@ -1,9 +1,11 @@
 /*
- * Copyright 2022 The CeresDB Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -21,7 +23,7 @@ import (
 	"context"
 	"path"
 
-	"github.com/CeresDB/ceresmeta/pkg/log"
+	"github.com/apache/incubator-horaedb-meta/pkg/log"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
 )

--- a/server/storage/key_path.go
+++ b/server/storage/key_path.go
@@ -36,6 +36,7 @@ const (
 	shardView     = "shard_view"
 	latestVersion = "latest_version"
 	info          = "info"
+	tableAssign   = "table_assign"
 )
 
 // makeSchemaKey returns the key path to the schema meta info.
@@ -126,6 +127,19 @@ func makeNameToIDKey(rootPath string, clusterID uint32, schemaID uint32, tableNa
 	//	v1/cluster/1/schema/1/table_name_to_id/table1 -> 1
 	//	v1/cluster/1/schema/1/table_name_to_id/table2 -> 2
 	return path.Join(rootPath, version, cluster, fmtID(uint64(clusterID)), schema, fmtID(uint64(schemaID)), tableNameToID, tableName)
+}
+
+// makeTableAssignKey return the tableAssign key path.
+func makeTableAssignKey(rootPath string, clusterID uint32, schemaID uint32, tableName string) string {
+	// Example:
+	//	v1/cluster/1/schema/1/table_assign/tableName1 -> shardID1
+	//	v1/cluster/1/schema/1/table_assign/tableName2 -> shardID2
+	return path.Join(rootPath, version, cluster, fmtID(uint64(clusterID)), schema, fmtID(uint64(schemaID)), tableAssign, tableName)
+}
+
+// makeTableAssignPrefixKey return the tableAssign prefix key path.
+func makeTableAssignPrefixKey(rootPath string, clusterID uint32, schemaID uint32) string {
+	return path.Join(rootPath, version, cluster, fmtID(uint64(clusterID)), schema, fmtID(uint64(schemaID)), tableAssign)
 }
 
 func fmtID(id uint64) string {

--- a/server/storage/meta.go
+++ b/server/storage/meta.go
@@ -57,6 +57,13 @@ type Storage interface {
 	// DeleteTable delete table by table name in specified cluster and schema.
 	DeleteTable(ctx context.Context, req DeleteTableRequest) error
 
+	// AssignTable save table assign result.
+	AssignTable(ctx context.Context, req AssignTableRequest) error
+	// DeleteAssignTable delete table assign result.
+	DeleteAssignTable(ctx context.Context, req DeleteAssignTableRequest) error
+	// ListAssignTable list table assign result.
+	ListAssignTable(ctx context.Context, req ListAssignTableRequest) (ListAssignTableResult, error)
+
 	// CreateShardViews create shard views in specified cluster.
 	CreateShardViews(ctx context.Context, req CreateShardViewsRequest) error
 	// ListShardViews list all shard views in specified cluster.

--- a/server/storage/meta.go
+++ b/server/storage/meta.go
@@ -57,12 +57,12 @@ type Storage interface {
 	// DeleteTable delete table by table name in specified cluster and schema.
 	DeleteTable(ctx context.Context, req DeleteTableRequest) error
 
-	// AssignTable save table assign result.
-	AssignTable(ctx context.Context, req AssignTableRequest) error
-	// DeleteAssignTable delete table assign result.
-	DeleteAssignTable(ctx context.Context, req DeleteAssignTableRequest) error
-	// ListAssignTable list table assign result.
-	ListAssignTable(ctx context.Context, req ListAssignTableRequest) (ListAssignTableResult, error)
+	// AssignTableToShard save table assign result.
+	AssignTableToShard(ctx context.Context, req AssignTableToShardRequest) error
+	// DeleteTableAssignedShard delete table assign result.
+	DeleteTableAssignedShard(ctx context.Context, req DeleteTableAssignedRequest) error
+	// ListTableAssignedShard list table assign result.
+	ListTableAssignedShard(ctx context.Context, req ListAssignTableRequest) (ListTableAssignedShardResult, error)
 
 	// CreateShardViews create shard views in specified cluster.
 	CreateShardViews(ctx context.Context, req CreateShardViewsRequest) error

--- a/server/storage/storage_impl.go
+++ b/server/storage/storage_impl.go
@@ -418,6 +418,73 @@ func (s *metaStorageImpl) DeleteTable(ctx context.Context, req DeleteTableReques
 	return nil
 }
 
+func (s *metaStorageImpl) AssignTable(ctx context.Context, req AssignTableRequest) error {
+	key := makeTableAssignKey(s.rootPath, uint32(req.ClusterID), uint32(req.SchemaID), req.TableName)
+
+	// Check if the key exists, if not，save table assign result; Otherwise, the table assign result already exists and return an error.
+	keyMissing := clientv3util.KeyMissing(key)
+	opCreateAssignTable := clientv3.OpPut(key, strconv.Itoa(int(req.ShardID)))
+
+	resp, err := s.client.Txn(ctx).
+		If(keyMissing).
+		Then(opCreateAssignTable).
+		Commit()
+	if err != nil {
+		return errors.WithMessagef(err, "create assign table, clusterID:%d, schemaID:%d, key:%s", req.ClusterID, req.ShardID, key)
+	}
+	if !resp.Succeeded {
+		return ErrCreateSchemaAgain.WithCausef("assign table may already exist, clusterID:%d, schemaID:%d, key:%s, resp:%v", req.ClusterID, req.SchemaID, key, resp)
+	}
+
+	return nil
+}
+
+func (s *metaStorageImpl) DeleteAssignTable(ctx context.Context, req DeleteAssignTableRequest) error {
+	key := makeTableAssignKey(s.rootPath, uint32(req.ClusterID), uint32(req.SchemaID), req.TableName)
+
+	keyExists := clientv3util.KeyExists(key)
+	opDeleteAssignTable := clientv3.OpDelete(key)
+
+	resp, err := s.client.Txn(ctx).
+		If(keyExists).
+		Then(opDeleteAssignTable).
+		Commit()
+	if err != nil {
+		return errors.WithMessagef(err, "delete assign table, clusterID:%d, schemaID:%d, tableName:%s", req.ClusterID, req.SchemaID, req.TableName)
+	}
+	if !resp.Succeeded {
+		return ErrDeleteTableAgain.WithCausef("assign table may have been deleted, clusterID:%d, schemaID:%d, tableName:%s", req.ClusterID, req.SchemaID, req.TableName)
+	}
+
+	return nil
+}
+
+func (s *metaStorageImpl) ListAssignTable(ctx context.Context, req ListAssignTableRequest) (ListAssignTableResult, error) {
+	key := makeTableAssignPrefixKey(s.rootPath, uint32(req.ClusterID), uint32(req.SchemaID))
+	rangeLimit := s.opts.MaxScanLimit
+
+	var tableAssigns []TableAssign
+	do := func(key string, value []byte) error {
+		tableName := etcdutil.GetLastPathSegment(key)
+		shardIDStr := string(value)
+		shardID, err := strconv.ParseUint(shardIDStr, 10, 32)
+		if err != nil {
+			return err
+		}
+		tableAssigns = append(tableAssigns, TableAssign{
+			TableName: tableName,
+			ShardID:   ShardID(shardID),
+		})
+		return nil
+	}
+
+	if err := etcdutil.ScanWithPrefix(ctx, s.client, key, rangeLimit, do); err != nil {
+		return ListAssignTableResult{}, errors.WithMessagef(err, "scan tables, clusterID:%d, schemaID:%d, prefix key:%s, range limit:%d", req.ClusterID, req.SchemaID, key, rangeLimit)
+	}
+
+	return ListAssignTableResult{TableAssigns: tableAssigns}, nil
+}
+
 func (s *metaStorageImpl) createNShardViews(ctx context.Context, clusterID ClusterID, shardViews []ShardView, ifConds []clientv3.Cmp, opCreates []clientv3.Op) error {
 	for _, shardView := range shardViews {
 		shardViewPB := convertShardViewToPB(shardView)

--- a/server/storage/storage_impl.go
+++ b/server/storage/storage_impl.go
@@ -418,7 +418,7 @@ func (s *metaStorageImpl) DeleteTable(ctx context.Context, req DeleteTableReques
 	return nil
 }
 
-func (s *metaStorageImpl) AssignTable(ctx context.Context, req AssignTableRequest) error {
+func (s *metaStorageImpl) AssignTableToShard(ctx context.Context, req AssignTableToShardRequest) error {
 	key := makeTableAssignKey(s.rootPath, uint32(req.ClusterID), uint32(req.SchemaID), req.TableName)
 
 	// Check if the key exists, if not，save table assign result; Otherwise, the table assign result already exists and return an error.
@@ -439,7 +439,7 @@ func (s *metaStorageImpl) AssignTable(ctx context.Context, req AssignTableReques
 	return nil
 }
 
-func (s *metaStorageImpl) DeleteAssignTable(ctx context.Context, req DeleteAssignTableRequest) error {
+func (s *metaStorageImpl) DeleteTableAssignedShard(ctx context.Context, req DeleteTableAssignedRequest) error {
 	key := makeTableAssignKey(s.rootPath, uint32(req.ClusterID), uint32(req.SchemaID), req.TableName)
 
 	keyExists := clientv3util.KeyExists(key)
@@ -459,7 +459,7 @@ func (s *metaStorageImpl) DeleteAssignTable(ctx context.Context, req DeleteAssig
 	return nil
 }
 
-func (s *metaStorageImpl) ListAssignTable(ctx context.Context, req ListAssignTableRequest) (ListAssignTableResult, error) {
+func (s *metaStorageImpl) ListTableAssignedShard(ctx context.Context, req ListAssignTableRequest) (ListTableAssignedShardResult, error) {
 	key := makeTableAssignPrefixKey(s.rootPath, uint32(req.ClusterID), uint32(req.SchemaID))
 	rangeLimit := s.opts.MaxScanLimit
 
@@ -478,11 +478,11 @@ func (s *metaStorageImpl) ListAssignTable(ctx context.Context, req ListAssignTab
 		return nil
 	}
 
-	if err := etcdutil.ScanWithPrefix(ctx, s.client, key, rangeLimit, do); err != nil {
-		return ListAssignTableResult{}, errors.WithMessagef(err, "scan tables, clusterID:%d, schemaID:%d, prefix key:%s, range limit:%d", req.ClusterID, req.SchemaID, key, rangeLimit)
+	if err := etcdutil.ScanWithPrefix(ctx, s.client, key, do); err != nil {
+		return ListTableAssignedShardResult{}, errors.WithMessagef(err, "scan tables, clusterID:%d, schemaID:%d, prefix key:%s, range limit:%d", req.ClusterID, req.SchemaID, key, rangeLimit)
 	}
 
-	return ListAssignTableResult{TableAssigns: tableAssigns}, nil
+	return ListTableAssignedShardResult{TableAssigns: tableAssigns}, nil
 }
 
 func (s *metaStorageImpl) createNShardViews(ctx context.Context, clusterID ClusterID, shardViews []ShardView, ifConds []clientv3.Cmp, opCreates []clientv3.Op) error {

--- a/server/storage/types.go
+++ b/server/storage/types.go
@@ -141,14 +141,14 @@ type DeleteTableRequest struct {
 	TableName string
 }
 
-type AssignTableRequest struct {
+type AssignTableToShardRequest struct {
 	ClusterID ClusterID
 	SchemaID  SchemaID
 	TableName string
 	ShardID   ShardID
 }
 
-type DeleteAssignTableRequest struct {
+type DeleteTableAssignedRequest struct {
 	ClusterID ClusterID
 	SchemaID  SchemaID
 	TableName string
@@ -159,7 +159,7 @@ type ListAssignTableRequest struct {
 	SchemaID  SchemaID
 }
 
-type ListAssignTableResult struct {
+type ListTableAssignedShardResult struct {
 	TableAssigns []TableAssign
 }
 

--- a/server/storage/types.go
+++ b/server/storage/types.go
@@ -141,6 +141,28 @@ type DeleteTableRequest struct {
 	TableName string
 }
 
+type AssignTableRequest struct {
+	ClusterID ClusterID
+	SchemaID  SchemaID
+	TableName string
+	ShardID   ShardID
+}
+
+type DeleteAssignTableRequest struct {
+	ClusterID ClusterID
+	SchemaID  SchemaID
+	TableName string
+}
+
+type ListAssignTableRequest struct {
+	ClusterID ClusterID
+	SchemaID  SchemaID
+}
+
+type ListAssignTableResult struct {
+	TableAssigns []TableAssign
+}
+
 type CreateShardViewsRequest struct {
 	ClusterID  ClusterID
 	ShardViews []ShardView
@@ -230,6 +252,11 @@ type Table struct {
 
 func (t Table) IsPartitioned() bool {
 	return t.PartitionInfo.Info != nil
+}
+
+type TableAssign struct {
+	TableName string
+	ShardID   ShardID
 }
 
 type ShardView struct {


### PR DESCRIPTION
## Rationale
Store the intermediate data for table creation through procedures to support idempotent table creation.

## Detailed Changes
* Store the intermediate data for table creation through procedure.
* Supports retrying from the upper layer to complete failed table creation procedures.

## Test Plan
Pass all unit tests and integration tests.