### PR TITLE
feat: add drop shard node api

### DIFF
--- a/server/service/http/api.go
+++ b/server/service/http/api.go
@@ -61,6 +61,7 @@ func (a *API) NewAPIRouter() *Router {
 	router.Post("/route", wrap(a.route, true, a.forwardClient))
 	router.Del("/table", wrap(a.dropTable, true, a.forwardClient))
 	router.Post("/getNodeShards", wrap(a.getNodeShards, true, a.forwardClient))
+	router.Del("/nodeShards", wrap(a.dropNodeShards, true, a.forwardClient))
 	router.Get("/flowLimiter", wrap(a.getFlowLimiter, true, a.forwardClient))
 	router.Put("/flowLimiter", wrap(a.updateFlowLimiter, true, a.forwardClient))
 	router.Get("/health", wrap(a.health, false, a.forwardClient))
@@ -201,6 +202,36 @@ func (a *API) getNodeShards(req *http.Request) apiFuncResult {
 	}
 
 	return okResult(result)
+}
+
+func (a *API) dropNodeShards(req *http.Request) apiFuncResult {
+	var dropNodeShardsRequest DropNodeShardsRequest
+	err := json.NewDecoder(req.Body).Decode(&dropNodeShardsRequest)
+	if err != nil {
+		return errResult(ErrParseRequest, err.Error())
+	}
+
+	c, err := a.clusterManager.GetCluster(req.Context(), dropNodeShardsRequest.ClusterName)
+	if err != nil {
+		log.Error("get cluster failed", zap.String("clusterName", dropNodeShardsRequest.ClusterName), zap.Error(err))
+		return errResult(ErrGetCluster, fmt.Sprintf("clusterName: %s, err: %s", dropNodeShardsRequest.ClusterName, err.Error()))
+	}
+
+	targetShardNodes := make([]storage.ShardNode, 0, len(dropNodeShardsRequest.ShardIDs))
+	getShardNodeResult := c.GetMetadata().GetShardNodes()
+	for _, shardNode := range getShardNodeResult.ShardNodes {
+		for _, shardID := range dropNodeShardsRequest.ShardIDs {
+			if shardNode.ID == storage.ShardID(shardID) {
+				targetShardNodes = append(targetShardNodes, shardNode)
+			}
+		}
+	}
+
+	if err := c.GetMetadata().DropShardNode(req.Context(), targetShardNodes); err != nil {
+		log.Error("drop node shards failed", zap.Error(err))
+		return errResult(ErrDropNodeShards, err.Error())
+	}
+	return okResult(statusSuccess)
 }
 
 func (a *API) dropTable(req *http.Request) apiFuncResult {

--- a/server/service/http/api.go
+++ b/server/service/http/api.go
@@ -231,7 +231,8 @@ func (a *API) dropNodeShards(req *http.Request) apiFuncResult {
 		log.Error("drop node shards failed", zap.Error(err))
 		return errResult(ErrDropNodeShards, err.Error())
 	}
-	return okResult(statusSuccess)
+
+	return okResult(targetShardNodes)
 }
 
 func (a *API) dropTable(req *http.Request) apiFuncResult {

--- a/server/service/http/error.go
+++ b/server/service/http/error.go
@@ -24,6 +24,7 @@ var (
 	ErrTable                         = coderr.NewCodeError(coderr.Internal, "table")
 	ErrRoute                         = coderr.NewCodeError(coderr.Internal, "route table")
 	ErrGetNodeShards                 = coderr.NewCodeError(coderr.Internal, "get node shards")
+	ErrDropNodeShards                = coderr.NewCodeError(coderr.Internal, "drop node shards")
 	ErrCreateProcedure               = coderr.NewCodeError(coderr.Internal, "create procedure")
 	ErrSubmitProcedure               = coderr.NewCodeError(coderr.Internal, "submit procedure")
 	ErrGetCluster                    = coderr.NewCodeError(coderr.Internal, "get cluster")

--- a/server/service/http/types.go
+++ b/server/service/http/types.go
@@ -116,6 +116,11 @@ type NodeShardsRequest struct {
 	ClusterName string `json:"clusterName"`
 }
 
+type DropNodeShardsRequest struct {
+	ClusterName string   `json:"clusterName"`
+	ShardIDs    []uint32 `json:"shardIDs"`
+}
+
 type DropTableRequest struct {
 	ClusterName string `json:"clusterName"`
 	SchemaName  string `json:"schemaName"`


### PR DESCRIPTION
## Rationale
In some extreme cases (for this situation, please refer to https://github.com/apache/incubator-horaedb-meta/issues/296), the shard node cannot be cleaned normally, and we need to add an operation and maintenance interface to complete manual cleaning.

## Detailed Changes
* Add drop shard node api.

## Test Plan
Pass CI.