### PR TITLE
feat!: upgrade horaedbproto

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/apache/incubator-horaedb-meta
 go 1.21
 
 require (
-	github.com/apache/incubator-horaedb-proto/golang v0.0.0-20231220150248-453c403a40cd
+	github.com/apache/incubator-horaedb-proto/golang v0.0.0-20231228071726-92152841fc8a
 	github.com/caarlos0/env/v6 v6.10.1
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/looplab/fsm v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/apache/incubator-horaedb-proto/golang v0.0.0-20231220150248-453c403a40cd h1:VoK1Blopwy9KTOgpPRrbnmc34cD1x2gpeml8944Hqmk=
-github.com/apache/incubator-horaedb-proto/golang v0.0.0-20231220150248-453c403a40cd/go.mod h1:Ch92HPIAoGbrgFCtpSgxcYSRgWdpNsIcPG1lfv24Ufs=
+github.com/apache/incubator-horaedb-proto/golang v0.0.0-20231228071726-92152841fc8a h1:lQVr4wkixN4N5dOKRUBU1lnqkiHTFg6Im+tqJ8Y7XOE=
+github.com/apache/incubator-horaedb-proto/golang v0.0.0-20231228071726-92152841fc8a/go.mod h1:Ch92HPIAoGbrgFCtpSgxcYSRgWdpNsIcPG1lfv24Ufs=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=

--- a/server/server.go
+++ b/server/server.go
@@ -101,7 +101,7 @@ func CreateServer(cfg *config.Config) (*Server, error) {
 
 	grpcService := metagrpc.NewService(cfg.GrpcHandleTimeout(), srv)
 	etcdCfg.ServiceRegister = func(grpcSrv *grpc.Server) {
-		grpcSrv.RegisterService(&metaservicepb.CeresmetaRpcService_ServiceDesc, grpcService)
+		grpcSrv.RegisterService(&metaservicepb.MetaRpcService_ServiceDesc, grpcService)
 	}
 
 	return srv, nil
@@ -227,7 +227,7 @@ func (srv *Server) startGrpcServer(_ context.Context) error {
 	server := grpc.NewServer(opts...)
 
 	grpcService := metagrpc.NewService(srv.cfg.GrpcHandleTimeout(), srv)
-	server.RegisterService(&metaservicepb.CeresmetaRpcService_ServiceDesc, grpcService)
+	server.RegisterService(&metaservicepb.MetaRpcService_ServiceDesc, grpcService)
 	addr := fmt.Sprintf(":%d", srv.cfg.GrpcPort)
 	lis, err := net.Listen("tcp", addr)
 	if err != nil {

--- a/server/service/grpc/forward.go
+++ b/server/service/grpc/forward.go
@@ -31,7 +31,7 @@ import (
 )
 
 // getForwardedMetaClient get forwarded horaemeta client. When current node is the leader, this func will return (nil,nil).
-func (s *Service) getForwardedMetaClient(ctx context.Context) (metaservicepb.CeresmetaRpcServiceClient, error) {
+func (s *Service) getForwardedMetaClient(ctx context.Context) (metaservicepb.MetaRpcServiceClient, error) {
 	forwardedAddr, _, err := s.getForwardedAddr(ctx)
 	if err != nil {
 		return nil, errors.WithMessage(err, "get forwarded horaemeta client")
@@ -47,12 +47,12 @@ func (s *Service) getForwardedMetaClient(ctx context.Context) (metaservicepb.Cer
 	return nil, nil
 }
 
-func (s *Service) getMetaClient(ctx context.Context, addr string) (metaservicepb.CeresmetaRpcServiceClient, error) {
+func (s *Service) getMetaClient(ctx context.Context, addr string) (metaservicepb.MetaRpcServiceClient, error) {
 	client, err := s.getForwardedGrpcClient(ctx, addr)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "get horaemeta client, addr:%s", addr)
 	}
-	return metaservicepb.NewCeresmetaRpcServiceClient(client), nil
+	return metaservicepb.NewMetaRpcServiceClient(client), nil
 }
 
 func (s *Service) getForwardedGrpcClient(ctx context.Context, forwardedAddr string) (*grpc.ClientConn, error) {

--- a/server/service/grpc/service.go
+++ b/server/service/grpc/service.go
@@ -42,7 +42,7 @@ import (
 )
 
 type Service struct {
-	metaservicepb.UnimplementedCeresmetaRpcServiceServer
+	metaservicepb.UnimplementedMetaRpcServiceServer
 	opTimeout time.Duration
 	h         Handler
 
@@ -53,10 +53,10 @@ type Service struct {
 
 func NewService(opTimeout time.Duration, h Handler) *Service {
 	return &Service{
-		UnimplementedCeresmetaRpcServiceServer: metaservicepb.UnimplementedCeresmetaRpcServiceServer{},
-		opTimeout:                              opTimeout,
-		h:                                      h,
-		conns:                                  sync.Map{},
+		UnimplementedMetaRpcServiceServer: metaservicepb.UnimplementedMetaRpcServiceServer{},
+		opTimeout:                         opTimeout,
+		h:                                 h,
+		conns:                             sync.Map{},
 	}
 }
 


### PR DESCRIPTION
## Rationale
Upgrade horaedbproto.

## Detailed Changes
Break changes:  Change `CeresmetaRpcService` to `MetaRpcService`.

## Test Plan
Due to Break changes, CI cannot pass. It is necessary to merge the changes on the `horaemeta` side first, and then modify the `horaedb` side.