### PR TITLE
chore!: replace ceresdb with test

### DIFF
--- a/server/cluster/manager_test.go
+++ b/server/cluster/manager_test.go
@@ -37,8 +37,8 @@ import (
 
 const (
 	defaultTimeout                     = time.Second * 20
-	cluster1                           = "ceresdbCluster1"
-	defaultSchema                      = "ceresdbSchema"
+	cluster1                           = "testCluster1"
+	defaultSchema                      = "testSchema"
 	defaultNodeCount                   = 2
 	defaultShardTotal                  = 8
 	defaultProcedureExecutingBatchSize = 100

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -59,7 +59,7 @@ const (
 
 	defaultNodeNamePrefix          = "horaemeta"
 	defaultEndpoint                = "127.0.0.1"
-	defaultRootPath                = "/ceresdb"
+	defaultRootPath                = "/horaedb"
 	defaultClientUrls              = "http://0.0.0.0:2379"
 	defaultPeerUrls                = "http://0.0.0.0:2380"
 	defaultInitialClusterState     = embed.ClusterStateFlagNew

--- a/server/coordinator/procedure/test/common.go
+++ b/server/coordinator/procedure/test/common.go
@@ -46,7 +46,7 @@ const (
 	TestSchemaName                     = "TestSchemaName"
 	TestRootPath                       = "/rootPath"
 	DefaultIDAllocatorStep             = 20
-	ClusterName                        = "ceresdbCluster1"
+	ClusterName                        = "testCluster1"
 	DefaultNodeCount                   = 2
 	DefaultShardTotal                  = 4
 	DefaultSchedulerOperator           = true


### PR DESCRIPTION
## Rationale
See https://github.com/apache/incubator-horaedb/issues/1319

## Detailed Changes
This is a breaking change. users need to add following config to keep back-compatitble
```
storage-root-path = "/ceresdb"
```
Or set via env vars 
```
export STORAGE_ROOT_PATH="/ceresdb"
```
## Test Plan
No need

